### PR TITLE
Fix right click crash error

### DIFF
--- a/anuga/pmesh/Pmw.py
+++ b/anuga/pmesh/Pmw.py
@@ -109,7 +109,7 @@ _busyStack = []
     # either directly or from activate()/deactivate()).  Each element
     # is a dictionary containing:
     #   'newBusyWindows' :  List of windows which had busy_hold called
-    #                       on them during a call to showbusycursor(). 
+    #                       on them during a call to showbusycursor().
     #                       The corresponding call to hidebusycursor()
     #                       will call busy_release on these windows.
     #   'busyFocus' :       The blt _Busy window which showbusycursor()
@@ -152,8 +152,8 @@ _grabStack = []
 
 # Functions used to forward methods from a class to a component.
 
-# Fill in a flattened method resolution dictionary for a class (attributes are 
-# filtered out). Flattening honours the MI method resolution rules 
+# Fill in a flattened method resolution dictionary for a class (attributes are
+# filtered out). Flattening honours the MI method resolution rules
 # (depth-first search of bases in order). The dictionary has method names
 # for keys and functions for values.
 def __methodDict(cls, dict):
@@ -162,7 +162,7 @@ def __methodDict(cls, dict):
     # order, and overwrite any duplicates.
     baseList = list(cls.__bases__)
     baseList.reverse()
-    
+
     # do bases in reverse order, so first base overrides last base
     for super in baseList:
 	__methodDict(super, dict)
@@ -182,9 +182,9 @@ def __methods(cls):
     dict = {}
     __methodDict(cls, dict)
     return dict.keys()
-	
-# Function body to resolve a forwarding given the target method name and the 
-# attribute name. The resulting lambda requires only self, but will forward 
+
+# Function body to resolve a forwarding given the target method name and the
+# attribute name. The resulting lambda requires only self, but will forward
 # any other parameters.
 __stringBody = (
     'def %(method)s(this, *args, **kw): return ' +
@@ -198,8 +198,8 @@ def __unique():
   return str(__counter)
 
 # Function body to resolve a forwarding given the target method name and the
-# index of the resolution function. The resulting lambda requires only self, 
-# but will forward any other parameters. The target instance is identified 
+# index of the resolution function. The resulting lambda requires only self,
+# but will forward any other parameters. The target instance is identified
 # by invoking the resolution function.
 __funcBody = (
     'def %(method)s(this, *args, **kw): return ' +
@@ -231,7 +231,7 @@ def forwardmethods(fromClass, toClass, toPart, exclude = ()):
     #             return self.__target
     #     forwardmethods(MyClass, TargetClass, '__target', ['dangerous1', 'dangerous2'])
     #     # ...or...
-    #     forwardmethods(MyClass, TargetClass, MyClass.findtarget, 
+    #     forwardmethods(MyClass, TargetClass, MyClass.findtarget,
     #             ['dangerous1', 'dangerous2'])
 
     # In both cases, all TargetClass methods will be forwarded from
@@ -248,7 +248,7 @@ def forwardmethods(fromClass, toClass, toPart, exclude = ()):
 	    # If a method is passed, use the function within it
 	    if hasattr(toPart, 'im_func'):
 		toPart = toPart.im_func
-		
+
 	    # After this is set up, forwarders in this class will use
 	    # the forwarding function. The forwarding function name is
 	    # guaranteed to be unique, so that it can't be hidden by subclasses
@@ -327,7 +327,7 @@ def setgeometryanddeiconify(window, geom):
         # takes about 2 seconds to appear.
 
         #window.tkraise()
-        # Call update_idletasks to ensure certain window managers (eg: 
+        # Call update_idletasks to ensure certain window managers (eg:
         # enlightenment and sawfish) do not cause Tk to delay for
         # about two seconds before displaying window.
         #window.update_idletasks()
@@ -729,7 +729,7 @@ class MegaArchetype:
 
 	for option, value in kw.items():
 	    if optionInfo_has_key(option):
-		# This is one of the options of this megawidget. 
+		# This is one of the options of this megawidget.
 		# Make sure it is not an initialisation option.
 		if optionInfo[option][FUNCTION] is INITOPT:
 		    raise KeyError('Cannot configure initialisation option "'
@@ -842,7 +842,7 @@ class MegaArchetype:
     def cget(self, option):
 	# Get current configuration setting.
 
-	# Return the value of an option, for example myWidget['font']. 
+	# Return the value of an option, for example myWidget['font'].
 
 	if self._optionInfo.has_key(option):
 	    return self._optionInfo[option][_OPT_VALUE]
@@ -914,7 +914,7 @@ class MegaArchetype:
 		rtn.append((alias, mainComponent))
 	    else:
 		rtn.append((alias, mainComponent + '_' + subComponent))
-	    
+
 	return rtn
 
     def componentgroup(self, name):
@@ -952,7 +952,7 @@ def popgrab(window):
     # If this window is not at the top of the grab stack, then it has
     # just been deleted by the window manager or deactivated by a
     # timer.  Call the deactivate method for the modal dialog above
-    # this one on the stack. 
+    # this one on the stack.
     if _grabStack[-1]['grabWindow'] != window:
         for index in range(len(_grabStack)):
             if _grabStack[index]['grabWindow'] == window:
@@ -1440,7 +1440,7 @@ def displayerror(text):
     if _errorReportFile is not None:
 	_errorReportFile.write(text + '\n')
     else:
-        # Print error on standard error as well as to error window. 
+        # Print error on standard error as well as to error window.
         # Useful if error window fails to be displayed, for example
         # when exception is triggered in a <Destroy> binding for root
         # window.
@@ -1520,7 +1520,7 @@ def initialise(
     Tkinter.CallWrapper = __TkinterCallWrapper
 
     # Make sure we get to know when the window manager deletes the
-    # root window.  Only do this if the protocol has not yet been set. 
+    # root window.  Only do this if the protocol has not yet been set.
     # This is required if there is a modal dialog displayed and the
     # window manager deletes the root window.  Otherwise the
     # application will not exit, even though there are no windows.
@@ -1529,7 +1529,7 @@ def initialise(
 
     # Set the base font size for the application and set the
     # Tk option database font resources.
-    
+
     _font_initialise(root, size, fontScheme)
 
     return root
@@ -1700,7 +1700,7 @@ class _BusyWrapper:
 def drawarrow(canvas, color, direction, tag, baseOffset = 0.25, edgeOffset = 0.15):
     canvas.delete(tag)
 
-    bw = (string.atoi(canvas['borderwidth']) + 
+    bw = (string.atoi(canvas['borderwidth']) +
             string.atoi(canvas['highlightthickness']))
     width = string.atoi(canvas['width'])
     height = string.atoi(canvas['height'])
@@ -1739,7 +1739,7 @@ def drawarrow(canvas, color, direction, tag, baseOffset = 0.25, edgeOffset = 0.1
 # Modify the Tkinter destroy methods so that it notifies us when a Tk
 # toplevel or frame is destroyed.
 
-# A map from the 'hull' component of a megawidget to the megawidget. 
+# A map from the 'hull' component of a megawidget to the megawidget.
 # This is used to clean up a megawidget when its hull is destroyed.
 _hullToMegaWidget = {}
 
@@ -1838,7 +1838,7 @@ def _reporterror(func, args):
     if type(exc_type) == types.ClassType:
 	# Handle python 1.5 class exceptions.
 	exc_type = exc_type.__name__
-    msg = exc_type + ' Exception in Tk callback\n'
+    msg = str(exc_type) + ' Exception in Tk callback\n'
     msg = msg + '  Function: %s (type: %s)\n' % (repr(func), type(func))
     msg = msg + '  Args: %s\n' % str(args)
 
@@ -1973,7 +1973,7 @@ class _ErrorWindow:
 	self._open = 0
 
     def _next(self):
-	# Display the next error in the queue. 
+	# Display the next error in the queue.
 
 	text = self._errorQueue[0]
 	del self._errorQueue[0]
@@ -2017,7 +2017,7 @@ class Dialog(MegaToplevel):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('buttonbox_hull_borderwidth',   1,         None),
 	    ('buttonbox_hull_relief',        'raised',  None),
@@ -2074,7 +2074,7 @@ class Dialog(MegaToplevel):
 		    Tkinter.Frame, (oldInterior,), relief = 'sunken',
 		    height = width, width = width, borderwidth = width / 2)
 	    self._separator.pack(side = side, fill = fill)
-	
+
 	# Create the child site.
 	self.__dialogChildSite = self.createcomponent('dialogchildsite',
 		(), None,
@@ -2087,7 +2087,7 @@ class Dialog(MegaToplevel):
 	self.bind('<Return>', self._invokeDefault)
         self.userdeletefunc(self._doCommand)
         self.usermodaldeletefunc(self._doCommand)
-	
+
 	# Check keywords and initialise options.
 	self.initialiseoptions()
 
@@ -2381,14 +2381,14 @@ class Balloon(MegaToplevel):
 	# Initialise instance variables.
 	self._timer = None
 
-        # The widget or item that is currently triggering the balloon. 
+        # The widget or item that is currently triggering the balloon.
         # It is None if the balloon is not being displayed.  It is a
         # one-tuple if the balloon is being displayed in response to a
         # widget binding (value is the widget).  It is a two-tuple if
         # the balloon is being displayed in response to a canvas or
         # text item binding (value is the widget and the item).
         self._currentTrigger = None
-	
+
 	# Check keywords and initialise options.
 	self.initialiseoptions()
 
@@ -2408,7 +2408,7 @@ class Balloon(MegaToplevel):
 
 	if statusHelp is None:
 	    statusHelp = balloonHelp
-	enterId = widget.bind('<Enter>', 
+	enterId = widget.bind('<Enter>',
 		lambda event, self = self, w = widget,
 			sHelp = statusHelp, bHelp = balloonHelp:
 				self._enter(event, w, sHelp, bHelp, 0))
@@ -2419,7 +2419,7 @@ class Balloon(MegaToplevel):
         # status line.
 	# Note:  The Motion binding only works for basic widgets, and
         # the hull of megawidgets but not for other megawidget components.
-	motionId = widget.bind('<Motion>', 
+	motionId = widget.bind('<Motion>',
 		lambda event = None, self = self, statusHelp = statusHelp:
 			self.showstatus(statusHelp))
 
@@ -2473,11 +2473,11 @@ class Balloon(MegaToplevel):
 
 	if statusHelp is None:
 	    statusHelp = balloonHelp
-	enterId = widget.tag_bind(tagOrItem, '<Enter>', 
+	enterId = widget.tag_bind(tagOrItem, '<Enter>',
 		lambda event, self = self, w = widget,
 			sHelp = statusHelp, bHelp = balloonHelp:
 				self._enter(event, w, sHelp, bHelp, 1))
-	motionId = widget.tag_bind(tagOrItem, '<Motion>', 
+	motionId = widget.tag_bind(tagOrItem, '<Motion>',
 		lambda event = None, self = self, statusHelp = statusHelp:
 			self.showstatus(statusHelp))
 	leaveId = widget.tag_bind(tagOrItem, '<Leave>', self._leave)
@@ -2567,7 +2567,7 @@ class Balloon(MegaToplevel):
 		self.after_cancel(self._timer)
 		self._timer = None
 
-	    self._timer = self.after(self['initwait'], 
+	    self._timer = self.after(self['initwait'],
 		    lambda self = self, widget = widget, help = balloonHelp,
 			    isItem = isItem:
 			    self._showBalloon(widget, help, isItem))
@@ -2600,7 +2600,7 @@ class Balloon(MegaToplevel):
     def _destroy(self, event):
 
         # Only withdraw the balloon and cancel the timer if the widget
-        # being destroyed is the widget that triggered the balloon. 
+        # being destroyed is the widget that triggered the balloon.
         # Note that in a Tkinter Destroy event, the widget field is a
         # string and not a widget as usual.
 
@@ -2711,7 +2711,7 @@ class ButtonBox(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('labelmargin',       0,              INITOPT),
 	    ('labelpos',          None,           INITOPT),
@@ -2946,7 +2946,7 @@ class EntryField(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('command',           None,        None),
 	    ('errorbackground',   'pink',      None),
@@ -2995,7 +2995,7 @@ class EntryField(MegaWidget):
         if EntryField._classBindingsDefinedFor != Tkinter._default_root:
 	    tagList = self._entryFieldEntry.bindtags()
             root  = Tkinter._default_root
-	    	    
+
 	    allSequences = {}
 	    for tag in tagList:
 
@@ -3067,7 +3067,7 @@ class EntryField(MegaWidget):
 	# Look up validator maps and replace 'stringtovalue' field
 	# with the corresponding function.
 	if dict.has_key('stringtovalue'):
-	    stringtovalue = dict['stringtovalue'] 
+	    stringtovalue = dict['stringtovalue']
 	    strFunction = self._getValidatorFunc(stringtovalue, 1)
 	    self._checkValidateFunction(
 		    strFunction, 'stringtovalue', stringtovalue)
@@ -3118,7 +3118,7 @@ class EntryField(MegaWidget):
                 return cmd()
             else:
                 cmd()
-	    
+
     def _preProcess(self):
 
         self._previousText = self._entryFieldEntry.get()
@@ -3146,7 +3146,7 @@ class EntryField(MegaWidget):
 	if callable(cmd) and previousText != self._entryFieldEntry.get():
 	    cmd()
 	return valid
-	    
+
     def checkentry(self):
 	# If there is a variable specified by the entry_textvariable
 	# option, checkentry() should be called after the set() method
@@ -3277,7 +3277,7 @@ def numericvalidator(text):
 	    return ERROR
 	else:
 	    return OK
-    
+
 def integervalidator(text):
     if text in ('', '-', '+'):
         return PARTIAL
@@ -3286,19 +3286,19 @@ def integervalidator(text):
 	return OK
     except ValueError:
 	return ERROR
-    
+
 def alphabeticvalidator(text):
     if _alphabeticregex.match(text) is None:
 	return ERROR
     else:
 	return OK
-    
+
 def alphanumericvalidator(text):
     if _alphanumericregex.match(text) is None:
 	return ERROR
     else:
 	return OK
-    
+
 def hexadecimalvalidator(text):
     if text in ('', '0x', '0X', '+', '+0x', '+0X', '-', '-0x', '-0X'):
         return PARTIAL
@@ -3307,7 +3307,7 @@ def hexadecimalvalidator(text):
 	return OK
     except ValueError:
 	return ERROR
-    
+
 def realvalidator(text, separator = '.'):
     if separator != '.':
 	if string.find(text, '.') >= 0:
@@ -3330,7 +3330,7 @@ def realvalidator(text, separator = '.'):
 	    return PARTIAL
 	except ValueError:
 	    return ERROR
-    
+
 def timevalidator(text, separator = ':'):
     try:
 	timestringtoseconds(text, separator)
@@ -3420,7 +3420,7 @@ class Group( MegaWidget ):
     def __init__(self, parent = None, **kw):
 
         # Define the megawidget options.
-	
+
         optiondefs = (
 	    ('collapsedsize',    6,         INITOPT),
 	    ('ring_borderwidth', 2,         None),
@@ -3436,9 +3436,9 @@ class Group( MegaWidget ):
         interior = MegaWidget.interior(self)
 
 	self._ring = self.createcomponent(
-	    'ring', 
+	    'ring',
 	    (), None,
-	    Tkinter.Frame, (interior,), 
+	    Tkinter.Frame, (interior,),
 	    )
 
 	self._groupChildSite = self.createcomponent(
@@ -3511,7 +3511,7 @@ class LabeledWidget(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('labelmargin',            0,      INITOPT),
 	    ('labelpos',               None,   INITOPT),
@@ -3553,7 +3553,7 @@ class MainMenuBar(MegaArchetype):
     def __init__(self, parent = None, **kw):
 
         # Define the megawidget options.
-        
+
         optiondefs = (
             ('balloon',      None,       None),
             ('hotkeys',      1,          INITOPT),
@@ -3671,7 +3671,7 @@ class MainMenuBar(MegaArchetype):
         self._menuInfo[menuName] = (parentMenuName, [])
 
         menu.bind('<Leave>', self._resetHelpmessage)
-        menu.bind('<Motion>', 
+        menu.bind('<Motion>',
             lambda event=None, self=self, menuName=menuName:
                     self._menuHelp(event, menuName))
 
@@ -3781,7 +3781,7 @@ class MenuBar(MegaWidget):
     def __init__(self, parent = None, **kw):
 
         # Define the megawidget options.
-        
+
         optiondefs = (
             ('balloon',      None,       None),
             ('hotkeys',      1,          INITOPT),
@@ -4025,7 +4025,7 @@ class MessageBar(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	defaultMessageTypes = {
 			   # (priority, showtime, bells, logmessage)
 	    'systemerror'  : (5, 10, 2, 1),
@@ -4170,7 +4170,7 @@ class MessageDialog(Dialog):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderx',       20,    INITOPT),
 	    ('bordery',       20,    INITOPT),
@@ -4246,7 +4246,7 @@ class NoteBook(MegaArchetype):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
         optiondefs = (
 	    ('hull_highlightthickness',  0,           None),
 	    ('hull_borderwidth',         0,           None),
@@ -4320,11 +4320,11 @@ class NoteBook(MegaArchetype):
 	self._topPageName = None
 
         # Canvas items used:
-        #   Per tab: 
+        #   Per tab:
         #       top and left shadow
         #       right shadow
         #       button
-        #   Per notebook: 
+        #   Per notebook:
         #       page
         #       top page
         #       left shadow
@@ -4437,7 +4437,7 @@ class NoteBook(MegaArchetype):
 
         self._layout()
         return page
-  		
+
     def add(self, pageName, **kw):
         return apply(self.insert, (pageName, len(self._pageNames)), kw)
 
@@ -4462,7 +4462,7 @@ class NoteBook(MegaArchetype):
             if self._topPageName == pageName:
                 self._hull.delete(self._topPageItem)
                 self._topPageName = None
-                                
+
             if self._withTabs:
                 self.destroycomponent(pageName + '-tab')
                 apply(self._hull.delete, pageInfo['tabitems'])
@@ -4720,12 +4720,12 @@ class NoteBook(MegaArchetype):
                 right2 = left + tabwidth + borderWidth
                 right3 = left + tabwidth + borderWidth * 0.5
 
-                self.coords(lightshadow, 
+                self.coords(lightshadow,
                     left, tabBottom2, left, tabTop2, left2, tabTop,
                     right2, tabTop, right3, tabTop2, left3, tabTop2,
                     left2, tabTop3, left2, tabBottom,
                     )
-                self.coords(darkshadow, 
+                self.coords(darkshadow,
                     right2, tabTop, right, tabTop2, right, tabBottom2,
                     right2, tabBottom, right2, tabTop3, right3, tabTop2,
                     )
@@ -4848,7 +4848,7 @@ class NoteBook(MegaArchetype):
 
         self._pending = {}
 
-# Need to do forwarding to get the pack, grid, etc methods. 
+# Need to do forwarding to get the pack, grid, etc methods.
 # Unfortunately this means that all the other canvas methods are also
 # forwarded.
 forwardmethods(NoteBook, Tkinter.Canvas, '_hull')
@@ -4864,7 +4864,7 @@ class OptionMenu(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('command',        None,       None),
             ('items',          (),         INITOPT),
@@ -4919,7 +4919,7 @@ class OptionMenu(MegaWidget):
         # Clean up old items and callback commands.
         for oldIndex in range(len(self._itemList)):
             tclCommandName = str(self._menu.entrycget(oldIndex, 'command'))
-            if tclCommandName != '':   
+            if tclCommandName != '':
                 self._menu.deletecommand(tclCommandName)
         self._menu.delete(0, 'end')
 	self._itemList = list(items)
@@ -5017,7 +5017,7 @@ class PanedWidget(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
             ('command',            None,         None),
             ('orient',             'vertical',   INITOPT),
@@ -5642,7 +5642,7 @@ class PanedWidget(MegaWidget):
 class PromptDialog(Dialog):
     def __init__(self, parent = None, **kw):
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderx',     20,    INITOPT),
 	    ('bordery',     20,    INITOPT),
@@ -5663,7 +5663,7 @@ class PromptDialog(Dialog):
 		EntryField, (interior,))
 	self._promptDialogEntry.pack(fill='x', expand=1,
 		padx = self['borderx'], pady = self['bordery'])
-	
+
         if not kw.has_key('activatecommand'):
             # Whenever this dialog is activated, set the focus to the
             # EntryField's entry widget.
@@ -5699,7 +5699,7 @@ class RadioSelect(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('buttontype',    'button',      INITOPT),
 	    ('command',       None,          None),
@@ -5735,7 +5735,7 @@ class RadioSelect(MegaWidget):
 	    self._singleSelect = 1
 	elif self['selectmode'] == 'multiple':
 	    self._singleSelect = 0
-	else: 
+	else:
 	    raise ValueError('bad selectmode option "' + self['selectmode']
                              + '": should be single or multiple')
 
@@ -5873,7 +5873,7 @@ class RadioSelect(MegaWidget):
 	self._buttonList = []
 	if self._singleSelect:
 	    self.selection = None
-	else: 
+	else:
 	    self.selection = []
 
     def __setSingleValue(self, value):
@@ -5929,7 +5929,7 @@ class ScrolledCanvas(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderframe',    0,            INITOPT),
 	    ('canvasmargin',   0,            INITOPT),
@@ -5952,7 +5952,7 @@ class ScrolledCanvas(MegaWidget):
 	    self.origInterior.grid_propagate(0)
 
 	if self['borderframe']:
-	    # Create a frame widget to act as the border of the canvas. 
+	    # Create a frame widget to act as the border of the canvas.
 	    self._borderframe = self.createcomponent('borderframe',
 		    (), None,
 		    Tkinter.Frame, (self.origInterior,),
@@ -5981,7 +5981,7 @@ class ScrolledCanvas(MegaWidget):
 
 	self.origInterior.grid_rowconfigure(2, weight = 1, minsize = 0)
 	self.origInterior.grid_columnconfigure(2, weight = 1, minsize = 0)
-	
+
 	# Create the horizontal scrollbar
 	self._horizScrollbar = self.createcomponent('horizscrollbar',
 		(), 'Scrollbar',
@@ -6087,10 +6087,10 @@ class ScrolledCanvas(MegaWidget):
 
         # Clean up previous scroll commands to prevent memory leak.
         tclCommandName = str(self._canvas.cget('xscrollcommand'))
-        if tclCommandName != '':   
+        if tclCommandName != '':
             self._canvas.deletecommand(tclCommandName)
         tclCommandName = str(self._canvas.cget('yscrollcommand'))
-        if tclCommandName != '':   
+        if tclCommandName != '':
             self._canvas.deletecommand(tclCommandName)
 
 	if self['hscrollmode'] == self['vscrollmode'] == 'dynamic':
@@ -6133,7 +6133,7 @@ class ScrolledCanvas(MegaWidget):
 	self.scrollTimer = None
 
         # Call update_idletasks to make sure that the containing frame
-        # has been resized before we attempt to set the scrollbars. 
+        # has been resized before we attempt to set the scrollbars.
         # Otherwise the scrollbars may be mapped/unmapped continuously.
         self._scrollRecurse = self._scrollRecurse + 1
         self.update_idletasks()
@@ -6152,7 +6152,7 @@ class ScrolledCanvas(MegaWidget):
 	# If both horizontal and vertical scrollmodes are dynamic and
 	# currently only one scrollbar is mapped and both should be
 	# toggled, then unmap the mapped scrollbar.  This prevents a
-	# continuous mapping and unmapping of the scrollbars. 
+	# continuous mapping and unmapping of the scrollbars.
 	if (self['hscrollmode'] == self['vscrollmode'] == 'dynamic' and
 		self._horizScrollbarNeeded != self._horizScrollbarOn and
 		self._vertScrollbarNeeded != self._vertScrollbarOn and
@@ -6221,7 +6221,7 @@ class ScrolledField(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('labelmargin',   0,      INITOPT),
 	    ('labelpos',      None,   INITOPT),
@@ -6279,7 +6279,7 @@ class ScrolledFrame(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderframe',    1,            INITOPT),
 	    ('horizflex',      'fixed',      self._horizflex),
@@ -6305,7 +6305,7 @@ class ScrolledFrame(MegaWidget):
 	    self.origInterior.grid_propagate(0)
 
 	if self['borderframe']:
-	    # Create a frame widget to act as the border of the clipper. 
+	    # Create a frame widget to act as the border of the clipper.
 	    self._borderframe = self.createcomponent('borderframe',
 		    (), None,
 		    Tkinter.Frame, (self.origInterior,),
@@ -6338,7 +6338,7 @@ class ScrolledFrame(MegaWidget):
 
 	self.origInterior.grid_rowconfigure(2, weight = 1, minsize = 0)
 	self.origInterior.grid_columnconfigure(2, weight = 1, minsize = 0)
-	
+
 	# Create the horizontal scrollbar
 	self._horizScrollbar = self.createcomponent('horizscrollbar',
 		(), 'Scrollbar',
@@ -6410,7 +6410,7 @@ class ScrolledFrame(MegaWidget):
 	if self.scrollTimer is None:
 	    self.scrollTimer = self.after_idle(self._scrollBothNow)
 
-    # Called when the user clicks in the horizontal scrollbar. 
+    # Called when the user clicks in the horizontal scrollbar.
     # Calculates new position of frame then calls reposition() to
     # update the frame and the scrollbar.
     def xview(self, mode = None, value = None, units = None):
@@ -6432,7 +6432,7 @@ class ScrolledFrame(MegaWidget):
 
 	self.reposition()
 
-    # Called when the user clicks in the vertical scrollbar. 
+    # Called when the user clicks in the vertical scrollbar.
     # Calculates new position of frame then calls reposition() to
     # update the frame and the scrollbar.
     def yview(self, mode = None, value = None, units = None):
@@ -6604,7 +6604,7 @@ class ScrolledFrame(MegaWidget):
 	self.scrollTimer = None
 
         # Call update_idletasks to make sure that the containing frame
-        # has been resized before we attempt to set the scrollbars. 
+        # has been resized before we attempt to set the scrollbars.
         # Otherwise the scrollbars may be mapped/unmapped continuously.
         self._scrollRecurse = self._scrollRecurse + 1
         self.update_idletasks()
@@ -6623,7 +6623,7 @@ class ScrolledFrame(MegaWidget):
 	# If both horizontal and vertical scrollmodes are dynamic and
 	# currently only one scrollbar is mapped and both should be
 	# toggled, then unmap the mapped scrollbar.  This prevents a
-	# continuous mapping and unmapping of the scrollbars. 
+	# continuous mapping and unmapping of the scrollbars.
 	if (self['hscrollmode'] == self['vscrollmode'] == 'dynamic' and
 		self._horizScrollbarNeeded != self._horizScrollbarOn and
 		self._vertScrollbarNeeded != self._vertScrollbarOn and
@@ -6680,7 +6680,7 @@ class ScrolledListBox(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('dblclickcommand',    None,            None),
 	    ('hscrollmode',        'dynamic',       self._hscrollMode),
@@ -6747,7 +6747,7 @@ class ScrolledListBox(MegaWidget):
         theTag = 'ScrolledListBoxTag'
         if ScrolledListBox._classBindingsDefinedFor != Tkinter._default_root:
             root  = Tkinter._default_root
-	    	    
+
             def doubleEvent(event):
                 _handleEvent(event, 'double')
             def keyEvent(event):
@@ -6887,10 +6887,10 @@ class ScrolledListBox(MegaWidget):
 
         # Clean up previous scroll commands to prevent memory leak.
         tclCommandName = str(self._listbox.cget('xscrollcommand'))
-        if tclCommandName != '':   
+        if tclCommandName != '':
             self._listbox.deletecommand(tclCommandName)
         tclCommandName = str(self._listbox.cget('yscrollcommand'))
-        if tclCommandName != '':   
+        if tclCommandName != '':
             self._listbox.deletecommand(tclCommandName)
 
 	if self['hscrollmode'] == self['vscrollmode'] == 'dynamic':
@@ -6933,7 +6933,7 @@ class ScrolledListBox(MegaWidget):
 	self.scrollTimer = None
 
         # Call update_idletasks to make sure that the containing frame
-        # has been resized before we attempt to set the scrollbars. 
+        # has been resized before we attempt to set the scrollbars.
         # Otherwise the scrollbars may be mapped/unmapped continuously.
         self._scrollRecurse = self._scrollRecurse + 1
         self.update_idletasks()
@@ -6952,7 +6952,7 @@ class ScrolledListBox(MegaWidget):
 	# If both horizontal and vertical scrollmodes are dynamic and
 	# currently only one scrollbar is mapped and both should be
 	# toggled, then unmap the mapped scrollbar.  This prevents a
-	# continuous mapping and unmapping of the scrollbars. 
+	# continuous mapping and unmapping of the scrollbars.
 	if (self['hscrollmode'] == self['vscrollmode'] == 'dynamic' and
 		self._horizScrollbarNeeded != self._horizScrollbarOn and
 		self._vertScrollbarNeeded != self._vertScrollbarOn and
@@ -7047,7 +7047,7 @@ def _handleEvent(event, eventType):
 
 ######################################################################
 ### File: PmwScrolledText.py
-# Based on iwidgets2.2.0/scrolledtext.itk code.   
+# Based on iwidgets2.2.0/scrolledtext.itk code.
 
 import Tkinter
 
@@ -7056,7 +7056,7 @@ class ScrolledText(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderframe',    0,            INITOPT),
 	    ('columnheader',   0,            INITOPT),
@@ -7081,7 +7081,7 @@ class ScrolledText(MegaWidget):
 	    interior.grid_propagate(0)
 
 	if self['borderframe']:
-	    # Create a frame widget to act as the border of the text 
+	    # Create a frame widget to act as the border of the text
 	    # widget.  Later, pack the text widget so that it fills
 	    # the frame.  This avoids a problem in Tk, where window
 	    # items in a text widget may overlap the border of the
@@ -7242,14 +7242,14 @@ class ScrolledText(MegaWidget):
 
     def appendtext(self, text):
         oldTop, oldBottom = self._textbox.yview()
-     
+
         disabled = (str(self._textbox.cget('state')) == 'disabled')
         if disabled:
             self._textbox.configure(state='normal')
         self._textbox.insert('end', text)
         if disabled:
             self._textbox.configure(state='disabled')
-     
+
         if oldBottom == 1.0:
             self._textbox.yview('moveto', 1.0)
 
@@ -7308,10 +7308,10 @@ class ScrolledText(MegaWidget):
 
         # Clean up previous scroll commands to prevent memory leak.
         tclCommandName = str(self._textbox.cget('xscrollcommand'))
-        if tclCommandName != '':   
+        if tclCommandName != '':
             self._textbox.deletecommand(tclCommandName)
         tclCommandName = str(self._textbox.cget('yscrollcommand'))
-        if tclCommandName != '':   
+        if tclCommandName != '':
             self._textbox.deletecommand(tclCommandName)
 
 	if self['hscrollmode'] == self['vscrollmode'] == 'dynamic':
@@ -7371,7 +7371,7 @@ class ScrolledText(MegaWidget):
 	self.scrollTimer = None
 
         # Call update_idletasks to make sure that the containing frame
-        # has been resized before we attempt to set the scrollbars. 
+        # has been resized before we attempt to set the scrollbars.
         # Otherwise the scrollbars may be mapped/unmapped continuously.
         self._scrollRecurse = self._scrollRecurse + 1
         self.update_idletasks()
@@ -7405,7 +7405,7 @@ class ScrolledText(MegaWidget):
 	# If both horizontal and vertical scrollmodes are dynamic and
 	# currently only one scrollbar is mapped and both should be
 	# toggled, then unmap the mapped scrollbar.  This prevents a
-	# continuous mapping and unmapping of the scrollbars. 
+	# continuous mapping and unmapping of the scrollbars.
 	if (self['hscrollmode'] == self['vscrollmode'] == 'dynamic' and
 		self._horizScrollbarNeeded != self._horizScrollbarOn and
 		self._vertScrollbarNeeded != self._vertScrollbarOn and
@@ -7419,7 +7419,7 @@ class ScrolledText(MegaWidget):
 	if self['hscrollmode'] == 'dynamic':
 
 	    # The following test is done to prevent continuous
-	    # mapping and unmapping of the horizontal scrollbar. 
+	    # mapping and unmapping of the horizontal scrollbar.
 	    # This may occur when some event (scrolling, resizing
 	    # or text changes) modifies the displayed text such
 	    # that the bottom line in the window is the longest
@@ -7647,13 +7647,13 @@ class HistoryText(ScrolledText):
 
 class SelectionDialog(Dialog):
     # Dialog window with selection list.
-    
+
     # Dialog window displaying a list and requesting the user to
     # select one.
 
     def __init__(self, parent = None, **kw):
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderx',     10,    INITOPT),
 	    ('bordery',     10,    INITOPT),
@@ -7706,7 +7706,7 @@ forwardmethods(SelectionDialog, ScrolledListBox, '_list')
 class TextDialog(Dialog):
     def __init__(self, parent = None, **kw):
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderx',     10,    INITOPT),
 	    ('bordery',     10,    INITOPT),
@@ -7752,13 +7752,13 @@ class TimeCounter(MegaWidget):
     """Up-down counter
 
     A TimeCounter is a single-line entry widget with Up and Down arrows
-    which increment and decrement the Time value in the entry.  
+    which increment and decrement the Time value in the entry.
     """
 
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('autorepeat',    1,    None),
 	    ('buttonaspect',  1.0,  INITOPT),
@@ -7905,80 +7905,80 @@ class TimeCounter(MegaWidget):
 	# Set bindings.
 
 	# Up hour
-	self._upHourArrowBtn.bind('<Configure>', 
-		lambda  event, s=self,button=self._upHourArrowBtn: 
+	self._upHourArrowBtn.bind('<Configure>',
+		lambda  event, s=self,button=self._upHourArrowBtn:
 		s._drawArrow(button, 'up'))
 
-	self._upHourArrowBtn.bind('<1>', 
-    	    	lambda event, s=self,button=self._upHourArrowBtn: 
+	self._upHourArrowBtn.bind('<1>',
+    	    	lambda event, s=self,button=self._upHourArrowBtn:
 		s._countUp(button, 3600))
 
-	self._upHourArrowBtn.bind('<Any-ButtonRelease-1>', 
+	self._upHourArrowBtn.bind('<Any-ButtonRelease-1>',
 		lambda event, s=self, button=self._upHourArrowBtn:
 		s._stopUpDown(button))
 
 	# Up minute
-	self._upMinuteArrowBtn.bind('<Configure>', 
-		lambda  event, s=self,button=self._upMinuteArrowBtn: 
+	self._upMinuteArrowBtn.bind('<Configure>',
+		lambda  event, s=self,button=self._upMinuteArrowBtn:
 		s._drawArrow(button, 'up'))
-	    
 
-	self._upMinuteArrowBtn.bind('<1>', 
-    	    	lambda event, s=self,button=self._upMinuteArrowBtn: 
+
+	self._upMinuteArrowBtn.bind('<1>',
+    	    	lambda event, s=self,button=self._upMinuteArrowBtn:
 		s._countUp(button, 60))
 
-	self._upMinuteArrowBtn.bind('<Any-ButtonRelease-1>', 
+	self._upMinuteArrowBtn.bind('<Any-ButtonRelease-1>',
 		lambda event, s=self, button=self._upMinuteArrowBtn:
 		s._stopUpDown(button))
 
 	# Up second
-	self._upSecondArrowBtn.bind('<Configure>', 
-		lambda  event, s=self,button=self._upSecondArrowBtn: 
+	self._upSecondArrowBtn.bind('<Configure>',
+		lambda  event, s=self,button=self._upSecondArrowBtn:
 		s._drawArrow(button, 'up'))
-	    
 
-	self._upSecondArrowBtn.bind('<1>', 
-    	    	lambda event, s=self,button=self._upSecondArrowBtn: 
+
+	self._upSecondArrowBtn.bind('<1>',
+    	    	lambda event, s=self,button=self._upSecondArrowBtn:
 		s._countUp(button, 1))
 
-	self._upSecondArrowBtn.bind('<Any-ButtonRelease-1>', 
+	self._upSecondArrowBtn.bind('<Any-ButtonRelease-1>',
 		lambda event, s=self, button=self._upSecondArrowBtn:
 		s._stopUpDown(button))
 
 	# Down hour
-	self._downHourArrowBtn.bind('<Configure>', 
-		lambda  event, s=self,button=self._downHourArrowBtn: 
+	self._downHourArrowBtn.bind('<Configure>',
+		lambda  event, s=self,button=self._downHourArrowBtn:
 		s._drawArrow(button, 'down'))
 
-	self._downHourArrowBtn.bind('<1>', 
-    	    	lambda event, s=self,button=self._downHourArrowBtn: 
+	self._downHourArrowBtn.bind('<1>',
+    	    	lambda event, s=self,button=self._downHourArrowBtn:
 		s._countDown(button, 3600))
-	self._downHourArrowBtn.bind('<Any-ButtonRelease-1>', 
+	self._downHourArrowBtn.bind('<Any-ButtonRelease-1>',
 		lambda event, s=self, button=self._downHourArrowBtn:
 		s._stopUpDown(button))
 
 
 	# Down minute
-	self._downMinuteArrowBtn.bind('<Configure>', 
-		lambda  event, s=self,button=self._downMinuteArrowBtn: 
+	self._downMinuteArrowBtn.bind('<Configure>',
+		lambda  event, s=self,button=self._downMinuteArrowBtn:
 		s._drawArrow(button, 'down'))
 
-	self._downMinuteArrowBtn.bind('<1>', 
+	self._downMinuteArrowBtn.bind('<1>',
     	    	lambda event, s=self,button=self._downMinuteArrowBtn:
                 s._countDown(button, 60))
-	self._downMinuteArrowBtn.bind('<Any-ButtonRelease-1>', 
+	self._downMinuteArrowBtn.bind('<Any-ButtonRelease-1>',
 		lambda event, s=self, button=self._downMinuteArrowBtn:
 		s._stopUpDown(button))
 
 	# Down second
-	self._downSecondArrowBtn.bind('<Configure>', 
-		lambda  event, s=self,button=self._downSecondArrowBtn: 
+	self._downSecondArrowBtn.bind('<Configure>',
+		lambda  event, s=self,button=self._downSecondArrowBtn:
 		s._drawArrow(button, 'down'))
 
-	self._downSecondArrowBtn.bind('<1>', 
-    	    	lambda event, s=self, button=self._downSecondArrowBtn: 
+	self._downSecondArrowBtn.bind('<1>',
+    	    	lambda event, s=self, button=self._downSecondArrowBtn:
 		s._countDown(button,1))
-	self._downSecondArrowBtn.bind('<Any-ButtonRelease-1>', 
+	self._downSecondArrowBtn.bind('<Any-ButtonRelease-1>',
 		lambda event, s=self, button=self._downSecondArrowBtn:
 		s._stopUpDown(button))
 
@@ -8032,7 +8032,7 @@ class TimeCounter(MegaWidget):
 
 	self._hour = string.atoi(list[0])
 	self._minute = string.atoi(list[1])
-	self._second = string.atoi(list[2]) 
+	self._second = string.atoi(list[2])
 
     	self._setHMS()
 
@@ -8091,7 +8091,7 @@ class TimeCounter(MegaWidget):
 	    else:
 	      delay = self['repeatrate']
 	    self._timerId = self.after(
-		delay, lambda self=self, factor=factor,increment=increment: 
+		delay, lambda self=self, factor=factor,increment=increment:
 		  self._count(factor,'running', increment))
 
     def _setHMS(self):
@@ -8137,7 +8137,7 @@ class AboutDialog(MessageDialog):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('applicationname',   '',          INITOPT),
 	    ('iconpos',           'w',         None),
@@ -8191,7 +8191,7 @@ class ComboBox(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('autoclear',          0,          INITOPT),
 	    ('buttonaspect',       1.0,        INITOPT),
@@ -8293,7 +8293,7 @@ class ComboBox(MegaWidget):
 	    self._entryWidget.bind('<F34>', self._postList)
 	    self._entryWidget.bind('<F28>', self._postList)
 
-            # Need to unpost the popup if the entryfield is unmapped (eg: 
+            # Need to unpost the popup if the entryfield is unmapped (eg:
             # its toplevel window is withdrawn) while the popup list is
             # displayed.
             self._entryWidget.bind('<Unmap>', self._unpostList)
@@ -8528,7 +8528,7 @@ class ComboBox(MegaWidget):
 	self._ignoreRelease = 0
 
     def _resizeArrow(self, event):
-	bw = (string.atoi(self._arrowBtn['borderwidth']) + 
+	bw = (string.atoi(self._arrowBtn['borderwidth']) +
 		string.atoi(self._arrowBtn['highlightthickness']))
 	newHeight = self._entryfield.winfo_reqheight() - 2 * bw
 	newWidth = int(newHeight * self['buttonaspect'])
@@ -8570,13 +8570,13 @@ forwardmethods(ComboBox, EntryField, '_entryfield')
 
 class ComboBoxDialog(Dialog):
     # Dialog window with simple combobox.
-    
+
     # Dialog window displaying a list and entry field and requesting
     # the user to make a selection or enter a value
 
     def __init__(self, parent = None, **kw):
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderx',    10,              INITOPT),
 	    ('bordery',    10,              INITOPT),
@@ -8638,7 +8638,7 @@ class Counter(MegaWidget):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('autorepeat',     1,             None),
 	    ('buttonaspect',   1.0,           INITOPT),
@@ -8744,7 +8744,7 @@ class Counter(MegaWidget):
 	entry.bind('<Down>', lambda event, s = self: s._key_decrement(event))
 	entry.bind('<Up>', lambda event, s = self: s._key_increment(event))
 
-	# Need to cancel the timer if an arrow button is unmapped (eg: 
+	# Need to cancel the timer if an arrow button is unmapped (eg:
 	# its toplevel window is withdrawn) while the mouse button is
 	# held down.  The canvas will not get the ButtonRelease event
 	# if it is not mapped, since the implicit grab is cancelled.
@@ -9012,7 +9012,7 @@ class CounterDialog(Dialog):
     def __init__(self, parent = None, **kw):
 
 	# Define the megawidget options.
-	
+
 	optiondefs = (
 	    ('borderx',    20,  INITOPT),
 	    ('bordery',    20,  INITOPT),
@@ -9036,7 +9036,7 @@ class CounterDialog(Dialog):
 		Counter, (interior,))
 	self._cdCounter.pack(fill='x', expand=1,
 		padx = self['borderx'], pady = self['bordery'])
-	
+
         if not kw.has_key('activatecommand'):
             # Whenever this dialog is activated, set the focus to the
             # Counter's entry widget.

--- a/anuga/pmesh/graphical_mesh_generator.py
+++ b/anuga/pmesh/graphical_mesh_generator.py
@@ -18,7 +18,7 @@ import anuga.load_mesh.loadASCII
 from anuga.alpha_shape.alpha_shape import AlphaError
 import anuga.utilities.log as log
 
-# CONSTANTS 
+# CONSTANTS
 VERT_SELECT_ADDING_SEG_COLOR = 'orange'
 SELECT_COLOR = 'red'
 TRIANGLE_COLOUR = 'green'
@@ -39,8 +39,8 @@ class Draw(AppShell.AppShell):
     frameHeight    = 600
 
 
-    
-    
+
+
     def createButtons(self):
         """
         Add buttons to the bottom of the GUI
@@ -53,7 +53,7 @@ class Draw(AppShell.AppShell):
               statusMessage='', command=self.clearMesh)
         self.buttonAdd('Close', helpMessage='Close Screen',
               statusMessage='', command=self.close)
-        
+
     def createBase(self):
         """
         Create the GUI framework.  Set up the GUI
@@ -72,7 +72,7 @@ class Draw(AppShell.AppShell):
         self.scrolledcanvas.pack(side=LEFT, expand=YES, fill=BOTH)
         self.canvas = self.scrolledcanvas.component('canvas')
         self.canvas.configure( background="white" )
-        
+
         self.canvas.pack(side=LEFT, expand=YES, fill=BOTH)
 
         Widget.bind(self.canvas, "<Button-1>", self.mouseDown)
@@ -83,7 +83,7 @@ class Draw(AppShell.AppShell):
 
         #self.root.bind("<KeyPress>", self.setRegular)
         #self.root.bind("<KeyRelease>", self.setRegular)
-        
+
 	self.scrolledcanvas.resizescrollregion()
 
 #     def setRegular(self, event):
@@ -105,28 +105,28 @@ class Draw(AppShell.AppShell):
                                  label='Save', command=self.saveDrawing)
         self.menuBar.addmenuitem('File', 'command', 'Save mesh',
                                  label='SaveAs...', command=self.saveAsDrawing)
-        
+
         self.menuBar.addmenuitem('File', 'separator')
         self.menuBar.addmenuitem('File', 'command',
                                  'Add ungenerated file from arcGIS',
                                  label='Add ungenerated file...',
                                  command=self.ImportUngenerate)
-        
+
         #self.menuBar.addmenuitem('File', 'command',
         #                         'Export ASCII obj',
         #                         label='Export ASCII obj',
         #                         command=self.exportObj)
-        
+
         self.menuBar.addmenuitem('File', 'command',
                                  'Export ASCII segment outline',
                                  label='Export ASCII segment outline...',
                                  command=self.exportASCIIsegmentoutlinefile)
-        
+
         self.menuBar.addmenuitem('File', 'command',
                                  'Export ASCII csv file',
                                  label='Export ASCII csv file...',
                                  command=self.exportPointsFile)
-        
+
         self.menuBar.addmenuitem('File', 'command',
                                  'add Segments to connect all vertices'  ,
                                  label='join vertices',
@@ -176,7 +176,7 @@ class Draw(AppShell.AppShell):
             self.modeClass[key] = Mode
             # for actions that occur when the mouse goes down
             self.mouseDownFunc[key] = mouseDownFunc
-         
+
     def createZooms(self):
         """
         Add zoom buttons to the top of the GUI
@@ -188,7 +188,7 @@ class Draw(AppShell.AppShell):
                       zoom, command=self.selectZoom,
                       balloonhelp='*%s zoom' % zoom,
                       statushelp='', home_dir=HOME_DIR)
-            
+
         ToolBarButton(self, self.toolbar,'1.0', 'zoomToMesh.gif',
                       command=self.ResizeToFitWrapper,
                       balloonhelp='Zooms to mesh size',
@@ -209,8 +209,8 @@ class Draw(AppShell.AppShell):
                 ('addVertex', self.windowAddVertex, 'add Vertex'),
                 ('edit', self.windowEdit, 'edit selected object'),
                 ('default', self.windowDefault, 'set default value for selected mode'),
-                ('joinVer', self.joinVerticesButton, 'add Segments to connect all vertices'),      
-             #   ('autoSeg', self.auto_segmentButton, 'add Segments to form alpha shape'), 
+                ('joinVer', self.joinVerticesButton, 'add Segments to connect all vertices'),
+             #   ('autoSeg', self.auto_segmentButton, 'add Segments to form alpha shape'),
                 ('autoSegGiveAlpha', self.auto_segmentGiveAlphaButton, 'add Segments to form alpha shape, specify alpha'),
                 ('meshGen', self.windowMeshGen, 'Generate Mesh')]:
             ToolBarButton(self, self.toolbar, key, '%s.gif' % key,
@@ -255,7 +255,7 @@ class Draw(AppShell.AppShell):
         Build the data structures for storing the mesh objects
         """
         self.mesh = mesh.Mesh()
-        
+
         self.Vertices = visualmesh.vPoints(mesh.Vertex)
         self.Segments = visualmesh.vSegments(mesh.Segment)
         self.Holes = visualmesh.vPoints(mesh.Hole)
@@ -276,7 +276,7 @@ class Draw(AppShell.AppShell):
         Automatically add some verts and segs to the mesh.Used in Debugging
 
         center and radius
-        
+
         """
         from anuga.coordinate_transforms.geo_reference import Geo_reference, \
              DEFAULT_ZONE
@@ -292,7 +292,7 @@ class Draw(AppShell.AppShell):
         factor = 2* math.pi/num_of_cuts
         for cut in range(num_of_cuts):
              cuts.append(cut*factor)
-        
+
         for radius in cuts:
             x = x_origin + r * math.cos(radius)
             y = y_origin + r * math.sin(radius)
@@ -305,8 +305,8 @@ class Draw(AppShell.AppShell):
         self.drawSegment(v,v_first)
         region = self.drawRegion(x_origin, y_origin, 0)
         region.setTag("setheight5")
-        
-        
+
+
         x_origin = 30-offset_x
         y_origin = 30-offset_y
         r = 5
@@ -316,7 +316,7 @@ class Draw(AppShell.AppShell):
         factor = 2* math.pi/num_of_cuts
         for cut in range(num_of_cuts):
              cuts.append(cut*factor)
-        
+
         for radius in cuts:
             x = x_origin + r * math.cos(radius)
             y = y_origin + r * math.sin(radius)
@@ -332,10 +332,10 @@ class Draw(AppShell.AppShell):
         self.mesh.geo_reference = Geo_reference(zone=DEFAULT_ZONE,
                                                 xllcorner=offset_x,
                                                 yllcorner=offset_y)
-            
+
         #Since the new vertex may be off screen
         self.scrolledcanvas.resizescrollregion()
-            
+
     def selectFunc(self, tag):
         """
         Change the current mode class
@@ -354,14 +354,14 @@ class Draw(AppShell.AppShell):
 
     def clearSelections(self):
         """
-        deselect objects that have been selected 
+        deselect objects that have been selected
         """
         if self.selMeshObject:
-            self.deselectMeshObject(self.selMeshObject, self.selMeshTag)       
+            self.deselectMeshObject(self.selMeshObject, self.selMeshTag)
         if self.selVertex:
             self.deselectVertex(self.selVertex, self.selVertexTag)
-          
-        
+
+
     def selectZoom(self, tag):
         """
         Zoom in or out of the current mesh view
@@ -387,25 +387,25 @@ class Draw(AppShell.AppShell):
             elif self.selMeshObject == obj:
                 obj.draw(self.canvas,obj.guiID,  scale =self.SCALE ,colour= SELECT_COLOR)
             else:
-                obj.draw(self.canvas,obj.guiID,  scale =self.SCALE ) 
+                obj.draw(self.canvas,obj.guiID,  scale =self.SCALE )
         top, bottom = self.scrolledcanvas.xview()
         xcenter  = (top + bottom)/2
-        xdiff =  xcenter - top  
+        xdiff =  xcenter - top
         xcnew = xcenter - xdiff/fraction
-        
+
         top, bottom = self.scrolledcanvas.yview()
         ycenter = (top + bottom)/2
         ydiff = ycenter - top
         ycnew = ycenter - ydiff/fraction
-        
+
         self.scrolledcanvas.resizescrollregion()
         # update so the moveto calls will work...
         self.scrolledcanvas.update()
         # but calling update now does make things jerky
         self.canvas.xview_moveto(xcnew)
         self.canvas.yview_moveto(ycnew)
-        
-    
+
+
     def windowAddVertex (self, parent):
         """
         add a vertex using a window and entering x y values.
@@ -414,7 +414,7 @@ class Draw(AppShell.AppShell):
         need to userstand toolbarbutton.py to know how to
         get rid of it.
         """
-        
+
         dialog = AddVertexDialog(self.canvas)
         if dialog.xyValuesOk:
             log.critical(str(dialog.x))
@@ -424,17 +424,17 @@ class Draw(AppShell.AppShell):
             self.ResizeToFit()
         else:
             log.critical("bad values")
-    
+
     def windowDefault (self, parent):
         """
-        
+
         the parent attribute isn't used by this function.
         need to userstand toolbarbutton.py to know how to
         get rid of it.
         """
         # self.UserMesh is a vMesh instance
         self.UserMesh.defaultWindow(self.canvas, self.curModeClass)
-    
+
     def windowEdit (self, parent):
         """
 
@@ -442,15 +442,15 @@ class Draw(AppShell.AppShell):
         need to userstand toolbarbutton.py to know how to
         get rid of it.
         """
-        if self.selMeshObject:   
+        if self.selMeshObject:
             self.UserMeshChanged = self.UserMesh.editWindow(self.canvas,
                                      self.selMeshObject,
                                      self.UserMeshChanged)
-    
+
     def auto_segmentButton (self, parent):
         self.auto_segment()
 
-        
+
     def auto_segmentGiveAlphaButton (self, parent):
         dialog = auto_segmentDialog(self.canvas, self.meshLastAlpha)
         if dialog.use_optimum.get() == SET_ALPHA:
@@ -468,8 +468,8 @@ class Draw(AppShell.AppShell):
                              remove_holes=dialog.remove_holes.get(),
                              smooth_indents=dialog.smooth_indents.get(),
                              expand_pinch=dialog.expand_pinch.get())
-           
-        
+
+
     def auto_segment (self, alpha = None,
                                  raw_boundary=True,
                                  remove_holes=False,
@@ -477,7 +477,7 @@ class Draw(AppShell.AppShell):
                                  expand_pinch=False ):
         """
         add Segments to bound all vertices
-        
+
         """
         if len(self.mesh.getUserVertices()) >= 3:
             try:
@@ -493,7 +493,7 @@ class Draw(AppShell.AppShell):
 
                 for drawOb in ObjectsToVisuallyDelete:
                     self.UserMesh.unvisualise(drawOb, self.canvas)
-                
+
                 for segment in newsegs:
                     self.serial +=1
                     self.uniqueID = 'M*%d' % self.serial
@@ -501,7 +501,7 @@ class Draw(AppShell.AppShell):
                                             self.uniqueID,
                                             self.canvas,
                                             self.SCALE)
-            
+
         else:
             showerror('pMesh',
                       'Three or more vetices are needed to be able to auto_segment.')
@@ -514,10 +514,10 @@ class Draw(AppShell.AppShell):
                              remove_holes=dialog.remove_holes.get(),
                              smooth_indents=dialog.smooth_indents.get(),
                              expand_pinch=dialog.expand_pinch.get())
-            
+
         for drawOb in ObjectsToVisuallyDelete:
             self.UserMesh.unvisualise(drawOb, self.canvas)
-                
+
         for segment in newsegs:
             self.serial +=1
             self.uniqueID = 'M*%d' % self.serial
@@ -525,14 +525,14 @@ class Draw(AppShell.AppShell):
                                     self.uniqueID,
                                     self.canvas,
                                     self.SCALE)
-        
+
     def joinVerticesButton (self, parent):
         self.joinVertices()
-        
+
     def joinVertices (self):
         """
         add Segments to connect all vertices
-        
+
         the parent attribute isn't used by this function.
         need to userstand toolbarbutton.py to know how to
         get rid of it.
@@ -549,7 +549,7 @@ class Draw(AppShell.AppShell):
         else:
             showerror('pMesh',
                       'Three or more vetices are needed to be able to join vertices.')
-        
+
     def windowMeshGen (self, parent):
         """
         The parent attribute isn't used by this function.
@@ -563,18 +563,18 @@ class Draw(AppShell.AppShell):
                                self.MeshMaxArea,
                                self.MeshnumTriangles,
                                self.MeshMaxAreaLast)
-        
+
         if dialog.ValuesOk:
             log.critical(str(dialog.minAngle))
             log.critical(str(dialog.maxArea))
-            
+
             self.clearSelections()
             self.canvas.delete(ALL)
             if dialog.goodMaxArea == True:
                 self.MeshMinAngle = dialog.minAngle
                 self.MeshMaxArea = dialog.maxArea
                 self.MeshMaxAreaLast = True
-                
+
                 self.mesh = self.MeshGenAreaAngle (dialog.minAngle,
                                           dialog.maxArea,
                                           self.mesh)
@@ -582,7 +582,7 @@ class Draw(AppShell.AppShell):
                 self.MeshMinAngle = dialog.minAngle
                 self.MeshnumTriangles  = dialog.numTriangles
                 self.MeshMaxAreaLast = False
-                
+
                 self.mesh = self.MeshGenAreaNumTriangles (dialog.minAngle,
                                           dialog.numTriangles,
                                           self.mesh)
@@ -592,7 +592,7 @@ class Draw(AppShell.AppShell):
             self.UserMeshChanged = False
             self.visualiseMesh(self.mesh)
             log.critical("Mesh Generation finished")
-            
+
     def MeshGenAreaAngle (self, minAngle, maxArea, mesh):
         """
         Generate a mesh, given a minAngle and max area
@@ -606,7 +606,7 @@ class Draw(AppShell.AppShell):
             # This doesn't catch tempMesh.generateMesh failing
             tempMesh = mesh
         return tempMesh
-        
+
 
     def MeshGenAreaNumTriangles (self, minAngle, numTriangles, mesh):
         """
@@ -614,7 +614,7 @@ class Draw(AppShell.AppShell):
         """
         #get big triangles
         #calc area
-        #calc max triangle area 
+        #calc max triangle area
         #
         tempMesh = mesh
         try:
@@ -626,11 +626,11 @@ class Draw(AppShell.AppShell):
         meshArea = tempMesh.tri_mesh.calc_mesh_area()
         maxArea = meshArea/numTriangles
 
-        
+
         return self.MeshGenAreaAngle (minAngle,
                                       maxArea,
                                       self.mesh)
-        
+
     def mouseDown(self, event):
         """
         On a mouse down event, depending on the current state,
@@ -644,21 +644,21 @@ class Draw(AppShell.AppShell):
         self.mouseDownCurFunc( self.lastx,
                                self.lasty,event) #!!! remove the event?
                                                  # do last
-   
+
     def rightMouseUp(self, event):
         """
         On a right mouse button up event select the nearest object.
         """
         found=False
         if event.widget.find_withtag(CURRENT): # if there's a widget with a tag
-            [tag,string] = self.canvas.gettags(CURRENT) # get a list of them
+            tag = self.canvas.gettags(CURRENT)[0] # get a list of them
             log.critical("tag %s" % str(tag))  #tags ('M*1008', 'current')
             if tag[:2] == 'M*':   #!!! this can be removed when there are
                 #    only mesh objects on screen
                 #key, value = string.split(tag, '*')
                 objectID = tag
                 log.critical("Found!! objectID: %s" % str(objectID))
-                
+
                 meshObjects = self.getAllUserMeshObjects()
                 # It may be a triangle, which is ignored
                 if meshObjects.hasKey(objectID):
@@ -673,7 +673,7 @@ class Draw(AppShell.AppShell):
 
     def getAllUserMeshObjects(self):
         return self.UserMesh
-        
+
     def DeleteSelectedMeshObject(self, event):
         """
         if an object is selected, delete it.
@@ -686,10 +686,10 @@ class Draw(AppShell.AppShell):
             ObjectsToVisuallyDelete = self.mesh.deleteMeshObject (self.selMeshObject)
             for drawOb in ObjectsToVisuallyDelete:
                 self.UserMesh.unvisualise(drawOb, self.canvas)
-                
+
             self.selMeshObject = None
             self.selMeshTag = None
-            
+
     def selectMeshObject(self, meshObject, objectID):
         """
         selected a mesh object.
@@ -698,7 +698,7 @@ class Draw(AppShell.AppShell):
         self.selMeshObject = meshObject
         self.selMeshTag = objectID
         meshObject.draw(self.canvas,objectID, scale =self.SCALE ,colour = SELECT_COLOR)
-    
+
     def deselectMeshObject(self, meshObject, objectID):
         """
         deselected a mesh object.
@@ -712,14 +712,14 @@ class Draw(AppShell.AppShell):
         else:
             meshObject.draw(self.canvas,objectID,
                         scale =self.SCALE )
-            
+
     def drag(self,x,y,event):
         """
         Hack function.  called when in select and left mouse goes down
         """
         pass
-    
-    
+
+
     def drawEastingNorthingVertex(self,x,y,event):
         """
         draw a vertex object, plus add it to the mesh data structure
@@ -739,7 +739,7 @@ class Draw(AppShell.AppShell):
                                   event) #FIXME why is event passed on.
         self.UserMeshChanged = True
         return vert
-    
+
     def drawVertex(self,x,y,event):
         """
         draw a vertex object, plus add it to the mesh data structure
@@ -753,7 +753,7 @@ class Draw(AppShell.AppShell):
         vert = self.Vertices.draw(x,y,self.mesh,self.uniqueID,self.SCALE,self.canvas,event)
         self.UserMeshChanged = True
         return vert
-     
+
     def drawHole(self,x,y,event):
         """
         draw a hole object, plus add it to the mesh data structure
@@ -764,8 +764,8 @@ class Draw(AppShell.AppShell):
         self.uniqueID = 'M*%d' % self.serial
         self.userMeshChanged = True
         hole = self.Holes.draw(x,y,self.mesh,self.uniqueID,self.SCALE,self.canvas,event)
-        return hole    
-    
+        return hole
+
     def drawRegion(self,x,y,event):
         """
         draw a region object, plus add it to the mesh data structure
@@ -776,7 +776,7 @@ class Draw(AppShell.AppShell):
         self.uniqueID = 'M*%d' % self.serial
         region = self.Regions.draw(x,y,self.mesh,self.uniqueID,self.SCALE,self.canvas,event)
         return region
-    
+
     def selectSegmentPoint(self,x,y, event):
         """
         logic when selecting a vertex object to add a segment
@@ -790,15 +790,15 @@ class Draw(AppShell.AppShell):
                 vertex = self.Vertices.getMeshObject(objectID)
                 found = True
                 log.critical("Found! vertex: %s" % str(vertex))
-            
+
         if found and self.selVertex == vertex:
             log.critical("The selected vertex has already been selected")
             #The selected vertex has already been selected
             # therefore deselect it
             self.deselectVertex(self.selVertex, self.selVertexTag)
             found = False
-                 
-        if found: 
+
+        if found:
             #A vertex has been selected!
             if self.selVertex:
                 if self.mesh.isUserSegmentNew(self.selVertex,vertex):
@@ -812,7 +812,7 @@ class Draw(AppShell.AppShell):
                 self.selectVertex(vertex,objectID)
         else:
             log.critical(" There are no widgets.  This happen's too much")
-                    
+
 
     def selectVertex(self, vertex,objectID):
         """
@@ -822,7 +822,7 @@ class Draw(AppShell.AppShell):
         self.selVertex = vertex
         self.selVertexTag = objectID
         vertex.draw(self.canvas,objectID, scale =self.SCALE ,colour = VERT_SELECT_ADDING_SEG_COLOR)
-    
+
     def deselectVertex(self, vertex,objectID):
         """
         deselect a vertex object when adding a segment
@@ -831,7 +831,7 @@ class Draw(AppShell.AppShell):
         self.selVertex = None
         self.selVertexTag = None
         vertex.draw(self.canvas,objectID,  scale =self.SCALE )
-         
+
     def drawSegment(self,v1,v2):
         """
         Create a seg object, draw it and add it to the mesh data structure
@@ -846,7 +846,7 @@ class Draw(AppShell.AppShell):
             log.critical("geo reference %s" % str(self.mesh.geo_reference))
         except:
             log.critical("no geo reference")
-        
+
     def visualiseMesh(self,mesh):
         """
         visualise vertices, segments, triangulation, holes
@@ -869,14 +869,14 @@ class Draw(AppShell.AppShell):
                                     self.uniqueID,
                                     self.canvas,
                                     self.SCALE)
-            
+
         for hole in mesh.getHoles():
             self.serial +=1
             self.uniqueID = 'M*%d' % self.serial
             self.Holes.visualise(hole,
                                     self.uniqueID,
                                     self.canvas,
-                                    self.SCALE)   
+                                    self.SCALE)
         for region in mesh.getRegions():
             self.serial +=1
             self.uniqueID = 'M*%d' % self.serial
@@ -892,7 +892,7 @@ class Draw(AppShell.AppShell):
             self.visualiseMesh(self.mesh)
             self.ResizeToFit()
             self.ResizeToFit()
-            
+
     def obsolete_nnormaliseMesh(self):
         if self.mesh:
             self.clearSelections()
@@ -901,11 +901,11 @@ class Draw(AppShell.AppShell):
             self.visualiseMesh(self.mesh)
             self.ResizeToFit()
             self.ResizeToFit()
-            
-        
+
+
     def clearMesh(self):
         """Clear the current mesh object, and the canvas """
-       
+
         self.clearSelections()
         self.canvas.delete(ALL)
         self.deleteMesh()
@@ -915,14 +915,14 @@ class Draw(AppShell.AppShell):
     def exportObj(self):
         fileType = "obj"
         fileTypeDesc = "obj mesh"
-        
+
         ofile = tkFileDialog.asksaveasfilename(filetypes=[(fileTypeDesc,
                                                            fileType),
                                                           ("All Files", "*")])
         if ofile:
             addOn = "." + fileType
             jumpback = - len(addOn)
-            if ofile[jumpback:] != addOn:  
+            if ofile[jumpback:] != addOn:
                 ofile = ofile + addOn
             try:
                 self.mesh.exportASCIIobj(ofile)
@@ -933,7 +933,7 @@ class Draw(AppShell.AppShell):
                 showerror('Export ASCII file',
                                    'No triangulation to export.')
 
-    
+
 
     def ImportUngenerate(self):
         ofile = tkFileDialog.askopenfilename(initialdir=self.currentPath,
@@ -942,42 +942,42 @@ class Draw(AppShell.AppShell):
         if ofile == "":
             # The user cancelled the loading action
             return
-        
+
         try:
             self.clearSelections()
             self.canvas.delete(ALL)
             dict = mesh.importUngenerateFile(ofile)
             self.mesh.addVertsSegs(dict)
-            
-        except SyntaxError: 
+
+        except SyntaxError:
             # This is assuming that the SyntaxError is thrown in
             # importUngenerateFile
             showerror('File error',
                       ofile + ' is not in the correct format.')
-        except IOError: 
+        except IOError:
             #!!! this error type can not be thrown?
             showerror('File error',
                       'file ' + ofile + ' could not be found.')
-        except RuntimeError: 
+        except RuntimeError:
             showerror('File error',
                   'file ' + ofile + ' has an unknown file type.')
-    
+
         self.visualiseMesh(self.mesh)
         self.ResizeToFit()
-        
+
     def exportASCIIsegmentoutlinefile(self):
-        
+
         ofile = tkFileDialog.asksaveasfilename(initialdir=self.currentPath,
                                                filetypes=[("mesh", "*.tsh *.msh"),
                                              ("All Files", "*")])
-           
+
         if ofile:
             # .tsh is the default file format
-            if (ofile[-4:] == ".tsh" or ofile[-4:] == ".msh"):  
+            if (ofile[-4:] == ".tsh" or ofile[-4:] == ".msh"):
                 self.currentFilePathName = ofile
             else:
                 self.currentFilePathName = ofile + ".tsh"
-                
+
             try:
                 self.mesh.exportASCIIsegmentoutlinefile(ofile)
             except IOError: #FIXME should this function be throwing any errors?
@@ -991,17 +991,17 @@ class Draw(AppShell.AppShell):
                                                 ("All Files", "*")])
         if ofile:
             # .csv is the default file format
-            if (ofile[-4:] == ".csv" or ofile[-4:] == ".pts"):  
+            if (ofile[-4:] == ".csv" or ofile[-4:] == ".pts"):
                 self.currentFilePathName = ofile
             else:
                 self.currentFilePathName = ofile + ".csv"
-                
+
             try:
                 self.mesh.exportPointsFile(ofile)
             except IOError:
                 showerror('Export ASCII file',
                                    'Can not write to file.')
-                    
+
     def importFile(self):
         """
         import mesh data from a variety of formats (currently 2!)
@@ -1016,7 +1016,7 @@ class Draw(AppShell.AppShell):
         if ofile == "":
             # The user cancelled the loading action
             return
-        
+
         try:
             newmesh = mesh.importMeshFromFile(ofile)
             self.currentPath, dummy = os.path.split(ofile)
@@ -1028,23 +1028,23 @@ class Draw(AppShell.AppShell):
             # use ResizeToFitWrapper
             self.visualiseMesh(self.mesh)
             self.ResizeToFit()
-       
-        except IOError: 
+
+        except IOError:
             #!!! this error type can not be thrown?
             showerror('File error',
                       'file ' + ofile + ' could not be loaded.')
 
-        except RuntimeError: 
+        except RuntimeError:
             showerror('File error',
                   'file ' + ofile + ' has an unknown file type.')
         # Could not get the file name to showup in the title
         #appname =  ofile + " - " + APPLICATION_NAME
-        
-        except load_mesh.loadASCII.TitleAmountError: 
+
+        except load_mesh.loadASCII.TitleAmountError:
             showerror('File error',
                   'file ' + ofile + ' has a bad title line (first line).')
 
-    
+
     def ResizeToFitWrapper(self, Parent):
         """
         The parent attribute isn't used by this function.
@@ -1052,7 +1052,7 @@ class Draw(AppShell.AppShell):
         get rid of it.
         """
         self.ResizeToFit()
-        
+
     def ResizeToFit(self):
         """Visualise the mesh so it fits in the window"""
         if self.mesh.getUserVertices() == []:
@@ -1061,7 +1061,7 @@ class Draw(AppShell.AppShell):
         self.scrolledcanvas.resizescrollregion()
         # I need this so the xview values are correct
         self.scrolledcanvas.update()
-        
+
         xtop, xbottom = self.scrolledcanvas.xview()
         ytop, ybottom = self.scrolledcanvas.yview()
         xdiff = xbottom-xtop
@@ -1076,9 +1076,9 @@ class Draw(AppShell.AppShell):
             self.ResizeToFit()
         else:
             # without 0.99 some of the mesh may be off screen
-            fraction = 0.99*min(xdiff,ydiff) 
+            fraction = 0.99*min(xdiff,ydiff)
             self.selectZoom(fraction)
-            
+
     def saveDrawing(self):
         """
         Save the current drawing
@@ -1097,10 +1097,10 @@ class Draw(AppShell.AppShell):
         ofile = tkFileDialog.asksaveasfilename(initialdir=self.currentPath,
                                                filetypes=[("mesh", "*.tsh *.msh"),
                                              ("All Files", "*")])
-           
+
         if ofile:
             # .tsh is the default file format
-            if (ofile[-4:] == ".tsh" or ofile[-4:] == ".msh"):  
+            if (ofile[-4:] == ".tsh" or ofile[-4:] == ".msh"):
                 self.currentFilePathName = ofile
             else:
                 self.currentFilePathName = ofile + ".tsh"
@@ -1114,13 +1114,13 @@ class Draw(AppShell.AppShell):
         - cancel, don't gen, don't save.  Yes - generate mesh, go to save
         screen.  No - goto save screen.  To implement this need to know when
         the user has done a change, and the mesh hasn't been generated.  If
-        there is no generated mesh do not prompt. 
+        there is no generated mesh do not prompt.
         """
         if (self.UserMeshChanged) and self.mesh.isTriangulation():
-            
+
             m = _show("Warning",
                                    "A triangulation has not been generated, after mesh changes.  Generate triangulation before saving?",
-                                   icon=QUESTION, 
+                                   icon=QUESTION,
                                    type=YESNOCANCEL)
             if m == "no":
                 self.mesh.export_mesh_file(currentFilePathName)
@@ -1133,7 +1133,7 @@ class Draw(AppShell.AppShell):
         else:
             self.mesh.export_mesh_file(currentFilePathName)
             self.UserMeshChanged = False
-            
+
     def initData(self):
         """
         Initialise various lists and flags
@@ -1155,27 +1155,27 @@ class Draw(AppShell.AppShell):
         mesh.Segment.set_default_tag("")
         self.UserMeshChanged = False
         self.meshLastAlpha = None
-        
+
         self.Visualise = True #Is the mesh shown or not?
-    
+
     def ipostscript(self):
         """
         Print the canvas as a postscript file
         """
         ofile = tkFileDialog.asksaveasfilename(initialdir=self.currentPath,
                                                filetypes=[("postscript", "ps"),
-                                                          ("All Files", "*")]) 
+                                                          ("All Files", "*")])
         if ofile:
-            if ofile[-3:] != ".ps":  
+            if ofile[-3:] != ".ps":
                 ofile = ofile + ".ps"
             postscript = self.canvas.postscript()
             fd = open(ofile, 'w')
             fd.write(postscript)
             fd.close()
-        
+
     def close(self):
         self.quit()
-        
+
     def createInterface(self):
         """
         Call all functions that create the GUI interface
@@ -1193,7 +1193,7 @@ class Draw(AppShell.AppShell):
         #print "FIX THIS BEFORE "
         #self.addCylinders() # !!!DSG start pmesh with a triangle
         self.selectFunc('pointer')
-        self.currentPath = os.getcwd() 
+        self.currentPath = os.getcwd()
 
     def loadtestmesh(self,ofile):
         """
@@ -1204,19 +1204,19 @@ class Draw(AppShell.AppShell):
         d = mesh.Vertex (0.0, 4.0)
         f = mesh.Vertex (4.0,0.0)
         g = mesh.Vertex (-5.0,5.0)
-        
+
         s1 = mesh.Segment(a,d)
         s2 = mesh.Segment(d,f)
         s3 = mesh.Segment(a,f)
 
         r1 = mesh.Region(0.3, 0.3)
-        
+
         m = mesh.Mesh(userVertices=[a,d,f,g], userSegments=[s1,s2,s3], regions=[r1] )
-        
+
         fd.close()
         log.critical('returning m')
         return oadtestmesh(ofile)
-         
+
 class  AddVertexDialog(Dialog):
     """
     Dialog box for adding a vertex by entering co-ordindates
@@ -1226,20 +1226,20 @@ class  AddVertexDialog(Dialog):
         GUI description
         """
         self.title("Add New Vertex")
-        
+
         Label(master, text='X position:').grid(row=0, sticky=W)
         Label(master, text='Y position:').grid(row=1, sticky=W)
 
         self.xstr   = Entry(master, width = 16, name ="entry")
         self.ystr  = Entry(master, width = 16)
-       
+
         self.xstr.grid(row=0, column=1, sticky=W)
         self.ystr.grid(row=1, column=1, sticky=W)
         self.xstr.focus_force()
         self.x  = 0
         self.y  = 0
         self.xyValuesOk = False
-  
+
 
     def apply(self):
         """
@@ -1249,11 +1249,11 @@ class  AddVertexDialog(Dialog):
             self.x = float(self.xstr.get())
             self.y = float(self.ystr.get())
             self.xyValuesOk = True
-            
+
         except ValueError:
             showerror('Bad Vertex values',
                                    'X Y values are not numbers.')
-        
+
 
 class  auto_segmentDialog(Dialog):
     """
@@ -1262,7 +1262,7 @@ class  auto_segmentDialog(Dialog):
     def __init__(self, parent, alpha):
         self.alpha = alpha
         Dialog.__init__(self, parent)
-        
+
     def body(self, master):
         """
         GUI description
@@ -1272,26 +1272,26 @@ class  auto_segmentDialog(Dialog):
         self.use_optimum = IntVar()
         self.use_optimum.set(AUTO) # should initialise the radio buttons.
                                    #  It doesn't
-                                   
-        #self.use_optimum.set(NO_SELECTION) 
-        self.ck = Radiobutton(master, value = AUTO, variable=self.use_optimum) 
+
+        #self.use_optimum.set(NO_SELECTION)
+        self.ck = Radiobutton(master, value = AUTO, variable=self.use_optimum)
         self.ck.grid(row=1, column=0)
         Label(master, text='Use optimum alpha').grid(row=1, column=1, sticky=W)
 
         self.ck2 = Radiobutton(master, value = SET_ALPHA,
-                               variable=self.use_optimum) 
+                               variable=self.use_optimum)
         self.ck2.grid(row=2, column=0)
-        
+
         Label(master, text='alpha:').grid(row=2, column=1, sticky=W)
         if (self.alpha):
             alphaVar = StringVar()
             alphaVar.set(self.alpha)
             self.alpha_str  = Entry(master,
                                      textvariable = alphaVar,
-                                     width = 16, name ="entry") 
-        else: 
+                                     width = 16, name ="entry")
+        else:
             self.alpha_str = Entry(master, width = 16, name ="entry")
-        
+
         self.alpha_str.grid(row=2, column=3, sticky=W)
 
         #boundary type buttons
@@ -1300,31 +1300,31 @@ class  auto_segmentDialog(Dialog):
         self.smooth_indents = IntVar()
         self.expand_pinch = IntVar()
         self.ck3 = Checkbutton(master, state=NORMAL,
-                               variable=self.raw_boundary) 
+                               variable=self.raw_boundary)
         self.ck3.grid(row=3, column=0)
         Label(master, text='Raw boundary').grid(row=3, column=1, sticky=W)
         #
         self.ck4 = Checkbutton(master, state=NORMAL,
-                               variable=self.remove_holes) 
+                               variable=self.remove_holes)
         self.ck4.grid(row=4, column=0)
         Label(master, text='Remove small holes').grid(row=4,column=1, sticky=W)
         #
         self.ck5 = Checkbutton(master,state=NORMAL,
-                               variable=self.smooth_indents) 
+                               variable=self.smooth_indents)
         self.ck5.grid(row=5, column=0)
         Label(master,
               text='Remove sharp indents').grid(row=5, column=1, sticky=W)
         #
         self.ck6 = Checkbutton(master,state=NORMAL,
-                               variable=self.expand_pinch) 
+                               variable=self.expand_pinch)
         self.ck6.grid(row=6, column=0)
         Label(master,
               text='Remove pinch off').grid(row=6, column=1,  sticky=W)
 
-        
+
         self.alpha  = 0
         self.alphaValueOk = False
-        
+
 
     def apply(self):
         """
@@ -1333,7 +1333,7 @@ class  auto_segmentDialog(Dialog):
         try:
             self.alpha = float(self.alpha_str.get())
             self.alphaValueOk = True
-            
+
         except ValueError:
             pass
             #showerror('Bad Alpha value',
@@ -1346,7 +1346,7 @@ class  auto_segmentFilterDialog(Dialog):
     """
     def __init__(self, parent):
         Dialog.__init__(self, parent)
-        
+
     def body(self, master):
         """
         GUI description
@@ -1357,36 +1357,36 @@ class  auto_segmentFilterDialog(Dialog):
         self.use_optimum.set(AUTO) # should initialise the radio buttons.
                                    #  It doesn't
         self.boundary_type = IntVar()
-                      
+
         #boundary type buttons
         self.raw_boundary = IntVar()
         self.remove_holes = IntVar()
         self.smooth_indents = IntVar()
         self.expand_pinch = IntVar()
-        
+
         self.ck3 = Checkbutton(master, state=NORMAL,
-                               variable=self.raw_boundary) 
+                               variable=self.raw_boundary)
         self.ck3.grid(row=3, column=0)
         Label(master, text='Raw boundary').grid(row=3, column=1, sticky=W)
         #
         self.ck4 = Checkbutton(master, state=NORMAL,
-                               variable=self.remove_holes) 
+                               variable=self.remove_holes)
         self.ck4.grid(row=4, column=0)
         Label(master, text='Remove small holes').grid(row=4,column=1, sticky=W)
         #
         self.ck5 = Checkbutton(master,state=NORMAL,
-                               variable=self.smooth_indents) 
+                               variable=self.smooth_indents)
         self.ck5.grid(row=5, column=0)
         Label(master,
               text='Remove sharp indents').grid(row=5, column=1, sticky=W)
         #
         self.ck6 = Checkbutton(master,state=NORMAL,
-                               variable=self.expand_pinch) 
+                               variable=self.expand_pinch)
         self.ck6.grid(row=6, column=0)
         Label(master,
               text='Remove pinch off').grid(row=6, column=1,  sticky=W)
-        
-        
+
+
 
 
 class  MeshGenDialog(Dialog):
@@ -1412,13 +1412,13 @@ class  MeshGenDialog(Dialog):
 
         Dialog.__init__(self, parent)
 
-        
+
     def body(self, master):
         """
         GUI description
         """
         self.title("Generate Mesh")
-        
+
         Label(master,
               text='Minimum Angle(0 - 40):').grid(row=0, sticky=W)
         Label(master,
@@ -1438,18 +1438,18 @@ class  MeshGenDialog(Dialog):
             maxAreaVar.set(self.maxArea)
             self.maxAreastr  = Entry(master,
                                      textvariable = maxAreaVar,
-                                     width = 16)    
+                                     width = 16)
             self.numTrianglesstr  = Entry(master,
-                                          width = 16) 
-        else: 
+                                          width = 16)
+        else:
             self.maxAreastr  = Entry(master,
                                      width = 16)
             self.maxAreastr.focus_force()
             numTrianglesVar = StringVar()
-            numTrianglesVar.set(self.numTriangles)    
+            numTrianglesVar.set(self.numTriangles)
             self.numTrianglesstr  = Entry(master,
                                           textvariable = numTrianglesVar,
-                                          width = 16) 
+                                          width = 16)
 
 
         self.minAnglestr.grid(row=0, column=1, sticky=W)
@@ -1475,14 +1475,14 @@ class  MeshGenDialog(Dialog):
             self.ValuesOk = False
             showerror('Bad mesh generation values',
                                    ' Values are not numbers.')
-        
-        try:    
+
+        try:
             self.maxArea = float(self.maxAreastr.get())
             MeshGenDialog.lastMaxArea =self.maxArea
         except ValueError:
             self.goodMaxArea = False
-         
-        try:    
+
+        try:
             self.numTriangles = int(self.numTrianglesstr.get())
             MeshGenDialog.lastNumTriangles =self.numTriangles
         except ValueError:
@@ -1498,7 +1498,7 @@ class  MeshGenDialog(Dialog):
             showerror('Bad mesh generation values',
                       'Give a maximum area OR number of triangles, not both.')
 
-        try: 
+        try:
             # value checking
             if self.minAngle <0.0 or self.minAngle >40.0:
                 raise IOError
@@ -1506,14 +1506,13 @@ class  MeshGenDialog(Dialog):
                 raise IOError
             if self.goodNumTriangles == True and self.numTriangles <=0:
                 raise IOError
-            
+
         except IOError:
             self.ValuesOk = False
             showerror('Bad mesh generation values',
                                    'Values are out of range.')
-        
+
 if __name__ == '__main__':
     draw = Draw()
     draw.run()
-    #profile.run('draw.run()', 'pmeshprof')    
-
+    #profile.run('draw.run()', 'pmeshprof')


### PR DESCRIPTION
The right-click is used to select a point in the mesh. When we do right-click on something else, it gives weird errors that may crash the program. This modification is an attempt to solve this issue.