### PR TITLE
make mpi optional

### DIFF
--- a/anuga/shallow_water/gpu/gpu_domain.h
+++ b/anuga/shallow_water/gpu/gpu_domain.h
@@ -13,7 +13,11 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdbool.h>
+#ifdef HAVE_MPI
 #include <mpi.h>
+#else
+#include "gpu_mpi_stubs.h"
+#endif
 #include "anuga_typedefs.h"
 #include "sw_domain.h"
 

--- a/anuga/shallow_water/gpu/gpu_domain_core.c
+++ b/anuga/shallow_water/gpu/gpu_domain_core.c
@@ -6,11 +6,11 @@
 #include <string.h>
 #include <math.h>
 #include <omp.h>
-#include <mpi.h>
+// MPI (or single-process stubs) come in via gpu_domain.h
+#include "gpu_domain.h"
 #ifdef HAVE_MPI_EXT_H
 #include <mpi-ext.h>
 #endif
-#include "gpu_domain.h"
 #include "gpu_omp_macros.h"
 
 // Domain initialization, memory management, and sync functions

--- a/anuga/shallow_water/gpu/gpu_flop.c
+++ b/anuga/shallow_water/gpu/gpu_flop.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <math.h>
 #include <omp.h>
-#include <mpi.h>
+// MPI (or single-process stubs) come in via gpu_domain.h
 #include "gpu_domain.h"
 
 // FLOP counters for Gordon Bell performance profiling

--- a/anuga/shallow_water/gpu/gpu_halo.c
+++ b/anuga/shallow_water/gpu/gpu_halo.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <math.h>
 #include <omp.h>
-#include <mpi.h>
+// MPI (or single-process stubs) come in via gpu_domain.h
 #include "gpu_domain.h"
 #include "gpu_omp_macros.h"
 #include "gpu_nvtx.h"

--- a/anuga/shallow_water/gpu/gpu_kernels.c
+++ b/anuga/shallow_water/gpu/gpu_kernels.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <math.h>
 #include <omp.h>
-#include <mpi.h>
+// MPI (or single-process stubs) come in via gpu_domain.h
 #include "gpu_domain.h"
 
 #include "gpu_device_helpers.h"

--- a/anuga/shallow_water/gpu/gpu_mpi_stubs.h
+++ b/anuga/shallow_water/gpu/gpu_mpi_stubs.h
@@ -1,0 +1,50 @@
+// Single-process MPI stubs for building the GPU kernels without MPI/mpi4py.
+//
+// Included by gpu_domain.h only when HAVE_MPI is NOT defined. The GPU kernels
+// already guard every real MPI call behind `nprocs > 1`, `num_neighbors == 0`,
+// or rank-role checks, so in single-process mode these symbols only need to
+// *compile* - they are never executed. The exceptions are the (unguarded)
+// flop-counter reductions and MPI_Wtime, which are given correct single-process
+// behaviour below.
+#ifndef GPU_MPI_STUBS_H
+#define GPU_MPI_STUBS_H
+
+#include <stddef.h>
+#include <string.h>
+#include <omp.h>
+
+// Opaque handles - only ever stored in structs, never dereferenced when
+// running single-process.
+typedef int MPI_Comm;
+typedef int MPI_Request;
+
+#define MPI_COMM_WORLD      0
+#define MPI_STATUSES_IGNORE NULL
+
+// Reduction ops are unused single-process; values are irrelevant.
+#define MPI_SUM 0
+#define MPI_MAX 0
+#define MPI_MIN 0
+
+// Datatype "handles" encode the element byte size, so the reduction stubs
+// below can copy the right number of bytes for any type.
+#define MPI_DOUBLE             sizeof(double)
+#define MPI_UNSIGNED_LONG_LONG sizeof(unsigned long long)
+
+// Single-process reductions: the global result is just the local input.
+// (For MPI_Reduce, root == self, so the copy is always correct here.)
+#define MPI_Allreduce(sendbuf, recvbuf, count, dtype, op, comm) \
+    memcpy((recvbuf), (sendbuf), (size_t)(count) * (size_t)(dtype))
+#define MPI_Reduce(sendbuf, recvbuf, count, dtype, op, root, comm) \
+    memcpy((recvbuf), (sendbuf), (size_t)(count) * (size_t)(dtype))
+
+// Point-to-point calls are only reached when num_neighbors > 0, i.e. never in
+// single-process mode. Provide no-op stubs so the code compiles.
+#define MPI_Isend(buf, count, dtype, dest, tag, comm, request)   (0)
+#define MPI_Irecv(buf, count, dtype, source, tag, comm, request) (0)
+#define MPI_Waitall(count, requests, statuses)                   (0)
+
+// Wall-clock timer for the flop counters (gpu_flop.c already includes <omp.h>).
+#define MPI_Wtime() omp_get_wtime()
+
+#endif // GPU_MPI_STUBS_H

--- a/anuga/shallow_water/gpu/gpu_rate_operator.c
+++ b/anuga/shallow_water/gpu/gpu_rate_operator.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <math.h>
 #include <omp.h>
-#include <mpi.h>
+// MPI (or single-process stubs) come in via gpu_domain.h
 #include "gpu_domain.h"
 #include "gpu_device_helpers.h"
 #include "gpu_omp_macros.h"

--- a/anuga/shallow_water/meson.build
+++ b/anuga/shallow_water/meson.build
@@ -123,11 +123,19 @@ except Exception as e:
   endif
 endif
 
-if mpi_dep.found() and have_mpi4py
+# "Full MPI" means we have both the C MPI library and mpi4py. Only then do we
+# build the GPU extension with real MPI (multi-GPU domain decomposition).
+# Otherwise we still build it, but against single-process stubs (gpu_mpi_stubs.h)
+# so multiprocessor_mode=2 works on a single GPU with no MPI/mpi4py installed.
+have_full_mpi = mpi_dep.found() and have_mpi4py
+
+if have_full_mpi
   mpi4py_incdir = mpi4py_check.stdout().strip()
   gpu_inc_dir = include_directories('../utilities', incdir_numpy, mpi4py_incdir, 'gpu')
+  message('GPU extension will be built WITH MPI support (multi-GPU enabled)')
 else
   gpu_inc_dir = include_directories('../utilities', incdir_numpy, 'gpu')
+  message('GPU extension will be built WITHOUT MPI (single-process stubs)')
 endif
 
 # GPU architecture option (only used when gpu_offload=true)
@@ -199,12 +207,18 @@ if get_option('gpu_aware_mpi') and gpu_offload
   message('GPU-aware MPI enabled')
 endif
 
+# Compile real MPI code paths only when MPI + mpi4py are present; otherwise the
+# kernels fall back to the single-process stubs in gpu/gpu_mpi_stubs.h.
+if have_full_mpi
+  gpu_c_args += ['-DHAVE_MPI']
+endif
+
 # Runtime GPU-aware MPI detection via MPIX_Query_cuda_support / MPIX_Query_rocm_support.
 # These are non-standard extensions present in Open MPI and MVAPICH2 GPU builds.
 # Only probe when actually building with GPU offloading: on CPU-only builds (CI on
 # macOS/Windows) Open MPI ships MPIX_Query_cuda_support() as a zero-returning stub
 # even without CUDA, causing a false-positive detection and a misleading message.
-if mpi_dep.found() and gpu_offload
+if have_full_mpi and gpu_offload
   if cc.has_header('mpi-ext.h', dependencies: [mpi_dep])
     if cc.has_function('MPIX_Query_cuda_support',
                        prefix: '#include <mpi.h>\n#include <mpi-ext.h>',
@@ -264,59 +278,63 @@ if get_option('use_nvtx')
   endif
 endif
 
-# Only build sw_domain_gpu_ext if MPI and mpi4py are available
-if mpi_dep.found() and have_mpi4py
+# Always build sw_domain_gpu_ext. With full MPI it supports multi-GPU domain
+# decomposition; without it, the kernels use single-process stubs so a single
+# GPU still works (multiprocessor_mode=2). HAVE_MPI4PY is forwarded to Cython so
+# the .pyx skips the mpi4py cimport when mpi4py is absent.
+if have_full_mpi
   gpu_deps = openmp_deps + [mpi_dep] + nvtx_dep
-
-  # On macOS, SIP strips DYLD_LIBRARY_PATH from child processes so libmpi.dylib
-  # is not found at dlopen time even though it is present in the conda env.
-  # Embed two rpaths:
-  #   @executable_path/../lib  — resolves to $CONDA_PREFIX/lib relative to the
-  #                              Python binary; portable across any conda env path
-  #   sys.prefix/lib           — absolute fallback for non-standard layouts
-  gpu_link_args = []
-  if host_machine.system() == 'darwin'
-    _py_prefix = run_command(py3, ['-c', 'import sys; print(sys.prefix)'], check: false)
-    if _py_prefix.returncode() == 0
-      _mpi_lib_dir = _py_prefix.stdout().strip() + '/lib'
-      gpu_link_args = [
-        '-Wl,-rpath,@executable_path/../lib',
-        '-Wl,-rpath,' + _mpi_lib_dir,
-      ]
-      message('macOS: embedding rpath for libmpi.dylib: ' + _mpi_lib_dir)
-    endif
-  endif
-
-  py3.extension_module('sw_domain_gpu_ext',
-    sources: [
-      'sw_domain_gpu_ext.pyx',
-      'gpu/gpu_domain_core.c',
-      'gpu/gpu_boundaries.c',
-      'gpu/gpu_kernels.c',
-      'gpu/gpu_halo.c',
-      'gpu/gpu_rate_operator.c',
-      'gpu/gpu_inlet_operator.c',
-      'gpu/gpu_culvert_operator.c',
-      'gpu/gpu_flop.c',
-      'gpu/core_kernels.c',
-    ],
-    c_args: gpu_c_args,
-    link_args: gpu_link_args,
-    include_directories: gpu_inc_dir,
-    dependencies: gpu_deps,
-    subdir: 'anuga/shallow_water',
-    install: true,
-  )
-
-  if gpu_offload
-    message('Unified extension built with GPU target')
-  else
-    message('Unified extension built with CPU multicore target')
-  endif
+  gpu_cython_args = ['--compile-time-env', 'HAVE_MPI4PY=True']
 else
-  # Expected on Windows (MSMPI has no mpicc/pkg-config) and minimal Linux installs.
-  # GPU tests will be skipped via ImportError on those platforms.
-  message('MPI or mpi4py not found - sw_domain_gpu_ext will NOT be built (multiprocessor_mode=2 unavailable)')
+  gpu_deps = openmp_deps + nvtx_dep
+  gpu_cython_args = ['--compile-time-env', 'HAVE_MPI4PY=False']
+endif
+
+# On macOS, SIP strips DYLD_LIBRARY_PATH from child processes so libmpi.dylib
+# is not found at dlopen time even though it is present in the conda env.
+# Embed two rpaths:
+#   @executable_path/../lib  — resolves to $CONDA_PREFIX/lib relative to the
+#                              Python binary; portable across any conda env path
+#   sys.prefix/lib           — absolute fallback for non-standard layouts
+gpu_link_args = []
+if host_machine.system() == 'darwin' and have_full_mpi
+  _py_prefix = run_command(py3, ['-c', 'import sys; print(sys.prefix)'], check: false)
+  if _py_prefix.returncode() == 0
+    _mpi_lib_dir = _py_prefix.stdout().strip() + '/lib'
+    gpu_link_args = [
+      '-Wl,-rpath,@executable_path/../lib',
+      '-Wl,-rpath,' + _mpi_lib_dir,
+    ]
+    message('macOS: embedding rpath for libmpi.dylib: ' + _mpi_lib_dir)
+  endif
+endif
+
+py3.extension_module('sw_domain_gpu_ext',
+  sources: [
+    'sw_domain_gpu_ext.pyx',
+    'gpu/gpu_domain_core.c',
+    'gpu/gpu_boundaries.c',
+    'gpu/gpu_kernels.c',
+    'gpu/gpu_halo.c',
+    'gpu/gpu_rate_operator.c',
+    'gpu/gpu_inlet_operator.c',
+    'gpu/gpu_culvert_operator.c',
+    'gpu/gpu_flop.c',
+    'gpu/core_kernels.c',
+  ],
+  c_args: gpu_c_args,
+  cython_args: gpu_cython_args,
+  link_args: gpu_link_args,
+  include_directories: gpu_inc_dir,
+  dependencies: gpu_deps,
+  subdir: 'anuga/shallow_water',
+  install: true,
+)
+
+if gpu_offload
+  message('Unified GPU extension built with GPU target')
+else
+  message('Unified GPU extension built with CPU multicore target')
 endif
 
 

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -17,9 +17,15 @@ from libc.string cimport memset
 import numpy as np
 cimport numpy as np
 
-# Import mpi4py's MPI_Comm type
-from mpi4py cimport MPI
-from mpi4py.libmpi cimport MPI_Comm
+# Import mpi4py's MPI_Comm type when building with MPI support; otherwise fall
+# back to a plain-int MPI_Comm matching the C single-process stubs
+# (gpu/gpu_mpi_stubs.h). HAVE_MPI4PY is a Cython compile-time env constant set by
+# meson based on whether MPI + mpi4py were found at build time.
+IF HAVE_MPI4PY:
+    from mpi4py cimport MPI
+    from mpi4py.libmpi cimport MPI_Comm
+ELSE:
+    ctypedef int MPI_Comm
 
 # External C declarations (from gpu/ subdirectory)
 cdef extern from "gpu_domain.h" nogil:
@@ -421,10 +427,15 @@ cdef MPI_Comm get_mpi_comm() noexcept:
 
     Note: noexcept is required because MPI_Comm is an int on some platforms
     (e.g., macOS), and Cython's default error return value (NULL) is incompatible.
+
+    In single-process builds (no mpi4py) this returns a stub communicator that is
+    never used: the C kernels only touch the communicator when nprocs > 1.
     """
-    import anuga.utilities.parallel_abstraction as pypar
-    cdef MPI.Comm comm = pypar.comm
-    return comm.ob_mpi
+    IF HAVE_MPI4PY:
+        import anuga.utilities.parallel_abstraction as pypar
+        return (<MPI.Comm>pypar.comm).ob_mpi
+    ELSE:
+        return <MPI_Comm>0  # MPI_COMM_WORLD stub; unused single-process
 
 
 cdef int get_mpi_rank():


### PR DESCRIPTION
Upon testing on AMD and Intel I realized that building MPI4PY with MPICH on Cray machines that are not NVIDIA is a royal pain in the neck - this will allow a single GPU build to go through to test performance and throughput. Will fix MPI later, this is a whole other adeventure 